### PR TITLE
Simplify Arrivals data

### DIFF
--- a/lib/commuter.ex
+++ b/lib/commuter.ex
@@ -9,9 +9,9 @@ defmodule Commuter do
     # Define workers and child supervisors to be supervised
     children = [
       # Starts a worker by calling: CommuterService.Worker.start_link(arg1, arg2, arg3)
-      worker(Commuter.Router, []),
       worker(Commuter.Tfl.TflSupervisor, []),
-      worker(Commuter.Station.StationSupervisor, [])
+      worker(Commuter.Station.StationSupervisor, []),
+      worker(Commuter.Router, [])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -5,6 +5,7 @@ defmodule Commuter.Router do
 
   alias Commuter.Station.Controller
 
+  plug Corsica, origins: "*"
   plug Plug.Logger
   plug :match
   plug :dispatch
@@ -31,11 +32,11 @@ defmodule Commuter.Router do
   get "/stations" do
     conn
     |> Controller.get_all_stations
-    # send back a list of all the stations currently active.
   end
 
   get "/stations/:station_id/:line_id/:direction" do
-    Controller.get_arrivals(conn)
+    conn
+    |> Controller.get_arrivals
   end
 
   match _ do

--- a/lib/router.ex
+++ b/lib/router.ex
@@ -34,7 +34,7 @@ defmodule Commuter.Router do
     |> Controller.get_all_stations
   end
 
-  get "/stations/:station_id/:line_id/:direction" do
+  get "/stations/:station_id/:line_id" do
     conn
     |> Controller.get_arrivals
   end

--- a/lib/station/arrivals.ex
+++ b/lib/station/arrivals.ex
@@ -25,6 +25,8 @@ defmodule Commuter.Station.Arrivals do
     %{acc | outbound: [train | acc.outbound]}
   end
 
+  defp into_direction(%Train{} = train, %Arrivals{} = acc), do: acc
+
   defp sort_train_lists(%Arrivals{inbound: inb_list, outbound: outb_list} = struct) do
     new_inb = sort_chronologically_with_interval(inb_list)
     new_outb = sort_chronologically_with_interval(outb_list)

--- a/lib/station/controller.ex
+++ b/lib/station/controller.ex
@@ -17,7 +17,8 @@ defmodule Commuter.Station.Controller do
   Fetches the station, line and direction params from the connection and tries
   to call the corresponding process to retrieve arrivals data.
 
-  Sends a response back to the client.
+  Sends a response back to the client - the response is a Station struct encoded
+  to a JSON String.
   """
   def get_arrivals(%Plug.Conn{} = conn) do
     conn
@@ -28,7 +29,6 @@ defmodule Commuter.Station.Controller do
   defp assign_arrival_params(%Plug.Conn{path_params: p} = conn) do
     conn
     |> Plug.Conn.assign(:pid, atomize_params({p["station_id"], p["line_id"]}))
-    |> Plug.Conn.assign(:direction, atomize_params(p["direction"]))
   end
 
   # atomize the params
@@ -50,13 +50,8 @@ defmodule Commuter.Station.Controller do
   defp call_process(%Plug.Conn{assigns: assigns} = conn) do
     assigns.pid
     |> Commuter.Station.get_arrivals
-    |> take_direction_list(assigns.direction)
     |> Poison.encode!
     |> send_response(200, conn)
-  end
-
-  defp take_direction_list(%Commuter.Station{} = station, direction) do
-    Map.get(station.arrivals, direction)
   end
 
   defp send_response(response_body, code, conn) do

--- a/lib/station/controller.ex
+++ b/lib/station/controller.ex
@@ -63,9 +63,4 @@ defmodule Commuter.Station.Controller do
     Plug.Conn.resp(conn, code, response_body)
   end
 
-  # defp only_distance_in_seconds(list_of_trains) do
-  #   list_of_trains
-  #   |> Enum.map(fn %Train{time_to_station: time} -> "#{time} secs" end)
-  # end
-
 end

--- a/lib/station/station.ex
+++ b/lib/station/station.ex
@@ -5,7 +5,7 @@ defmodule Commuter.Station do
   alias Commuter.Station.Arrivals
   alias __MODULE__, as: Station
 
-  defstruct [:station_id, :line_id, :arrivals, timestamp: Timex.zero]
+  defstruct [:station_id, :station_name, :line_id, :arrivals, timestamp: Timex.zero]
 
   @tfl_api Application.get_env(:commuter, :tfl_api)
   @vsn "0"
@@ -20,9 +20,9 @@ defmodule Commuter.Station do
   ```
   Station ID and line ID are both passed to the `init` function.
   """
-  def start_link(station_id, line_id) do
+  def start_link(station_id, station_name, line_id) do
     pname = create_process_name(station_id, line_id)
-    GenServer.start_link(__MODULE__, {station_id, line_id}, name: pname)
+    GenServer.start_link(__MODULE__, {{station_id, line_id}, station_name}, name: pname)
   end
 
   @doc """
@@ -43,9 +43,10 @@ defmodule Commuter.Station do
 
   # Server callbacks
 
-  def init({station_id, line_id}) do
+  def init({{station_id, line_id}, station_name}) do
     IO.puts "Arrivals board is starting up for station #{station_id}"
-    initial_state = %Station{station_id: station_id, line_id: line_id}
+    initial_state =
+      %Station{station_id: station_id, line_id: line_id, station_name: station_name}
     {:ok, initial_state}
   end
 

--- a/lib/station/station.ex
+++ b/lib/station/station.ex
@@ -45,8 +45,9 @@ defmodule Commuter.Station do
 
   def init({{station_id, line_id}, station_name}) do
     IO.puts "Arrivals board is starting up for station #{station_id}"
+    tidy_name = tidy_name(station_name)
     initial_state =
-      %Station{station_id: station_id, line_id: line_id, station_name: station_name}
+      %Station{station_id: station_id, line_id: line_id, station_name: tidy_name}
     {:ok, initial_state}
   end
 
@@ -59,6 +60,10 @@ defmodule Commuter.Station do
 
   defp create_process_name(station_id, line_id) do
     "#{station_id}_#{line_id}" |> String.to_atom
+  end
+
+  defp tidy_name(string) do
+    String.replace(string, ~r/ Underground Station/, "")
   end
 
   # Business Logic
@@ -92,13 +97,6 @@ defmodule Commuter.Station do
         @tfl_api.take_body(response) |> create_cache(cache)
     end
   end
-
-  # defp create_cache(http_response_body, %Station{} = cache) do
-  #   new_struct = %Station{station_id: cache.station_id, line_id: cache.line_id}
-  #   http_response_body
-  #   |> Train.create_train_structs
-  #   |> Arrivals.build_arrivals_struct(new_struct)
-  # end
 
   defp create_cache(http_response_body, %Station{} = cache) do
     http_response_body

--- a/lib/station/station_supervisor.ex
+++ b/lib/station/station_supervisor.ex
@@ -20,12 +20,12 @@ defmodule Commuter.Station.StationSupervisor do
   end
 
   defp create_line_workers(%Commuter.Tfl.Station{lines: lines} = station) do
-    Enum.map(lines, &(create_worker(station.id, &1)) )
+    Enum.map(lines, &(create_worker(station.id, station.name, &1)) )
   end
 
-  defp create_worker(station_id, line_id) do
+  defp create_worker(station_id, station_name, line_id) do
     pname = create_process_name(station_id, line_id)
-    worker(Commuter.Station, [station_id, line_id], [id: pname])
+    worker(Commuter.Station, [station_id, station_name, line_id], [id: pname])
   end
 
   defp create_process_name(station_id, line_id) do

--- a/lib/tfl/station.ex
+++ b/lib/tfl/station.ex
@@ -75,7 +75,7 @@ defmodule Commuter.Tfl.Station do
 
   defp convert_to_struct(map) do
     lines = find_lines(map)
-    name = map["commonName"]
+    name = tidy_name(map["commonName"])
     id = map["naptanId"]
     %Commuter.Tfl.Station{id: id, name: name, lines: lines}
   end
@@ -88,6 +88,10 @@ defmodule Commuter.Tfl.Station do
 
   defp get_line_list(map) do
     map["lineIdentifier"]
+  end
+
+  defp tidy_name(string) do
+    String.replace(string, ~r/ Underground Station/, "")
   end
 
 end

--- a/lib/train/train.ex
+++ b/lib/train/train.ex
@@ -23,12 +23,16 @@ defmodule Commuter.Train do
       arrival_time: @tfl_api.to_datetime(map["expectedArrival"]),
       time_to_station: map["timeToStation"],
       destination: %{
-        destination_name: map["destinationName"],
+        destination_name: tidy_name(map["destinationName"]),
         destination_id: map["destinationNaptanId"]
       },
       train_id: map["vehicleId"],
       direction: map["direction"]
     }
+  end
+
+  defp tidy_name(string) do
+    String.replace(string, ~r/ Underground Station/, "")
   end
 
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,8 @@ defmodule Commuter.Mixfile do
       {:httpotion, "~> 3.0.2"},
       {:poison, "~> 3.0"},
       {:timex, "~> 3.0"},
-      {:distillery, "~> 1.0"}
+      {:distillery, "~> 1.0"},
+      {:corsica, "~> 0.5.0"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"certifi": {:hex, :certifi, "0.7.0", "861a57f3808f7eb0c2d1802afeaae0fa5de813b0df0979153cbafcd853ababaf", [:rebar3], []},
   "combine": {:hex, :combine, "0.9.6", "8d1034a127d4cbf6924c8a5010d3534d958085575fa4d9b878f200d79ac78335", [:mix], []},
+  "corsica": {:hex, :corsica, "0.5.0", "eb5b2fccc5bc4f31b8e2b77dd15f5f302aca5d63286c953e8e916f806056d50c", [:mix], [{:cowboy, ">= 1.0.0", [hex: :cowboy, optional: false]}, {:plug, ">= 0.9.0", [hex: :plug, optional: false]}]},
   "cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:make, :rebar], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
   "distillery": {:hex, :distillery, "1.1.0", "e9943bd29557e9c252a051d8ac4b47e597cd9bf2a74332b8628eab4954eb51d7", [:mix], []},

--- a/test/station/station_controller_test.exs
+++ b/test/station/station_controller_test.exs
@@ -7,11 +7,11 @@ defmodule Commuter.Station.ControllerTest do
 
   setup do
     bad_arrivals_resp =
-      conn(:get, "/stations/940GZZFAKE/northern/outbound")
+      conn(:get, "/stations/940GZZFAKE/northern")
       |> Commuter.Router.call(@opts)
       |> Controller.get_arrivals
     good_arrivals_resp =
-      conn(:get, "stations/940GZZLUTBC/northern/outbound")
+      conn(:get, "stations/940GZZLUTBC/northern")
       |> Commuter.Router.call(@opts)
       |> Controller.get_arrivals
     stations_resp =
@@ -43,15 +43,30 @@ defmodule Commuter.Station.ControllerTest do
     Enum.each(assigns, fn {_k,v} -> assert is_atom(v) end)
   end
 
-  test "a good request returns a string of json objects", %{responses: %{good_arrivals_resp: resp}} do
+  test "a good request returns valid json",
+  %{responses: %{good_arrivals_resp: resp}} do
     {code, _maps} = Poison.decode(resp.resp_body)
     assert code == :ok
   end
 
-  test "the /stations endpoint returns a list of json objects", %{stations_resp: resp} do
+  test "a good request returns a string that has station id and name keys",
+  %{responses: %{good_arrivals_resp: resp}} do
+    parsed_resp = Poison.decode!(resp.resp_body)
+    assert Map.has_key?(parsed_resp, "station_name")
+    assert Map.has_key?(parsed_resp, "station_id")
+  end
+
+  test "a good request returns an object with arrivals map with lists inside",
+  %{responses: %{good_arrivals_resp: resp}} do
+    arrivals_map =Poison.decode!(resp.resp_body) |> Map.get("arrivals")
+    assert Map.has_key?(arrivals_map, "inbound")
+    assert Map.has_key?(arrivals_map, "outbound")
+  end
+
+  test "the /stations endpoint returns a list of json objects",
+  %{stations_resp: resp} do
     {code, _maps} = Poison.decode(resp.resp_body)
     assert code == :ok
   end
-
 
 end


### PR DESCRIPTION
The aim of this PR is to:

- simplify the data flowing between the front and back ends of the app
- remove the `direction` param from arrivals requests. Instead, just send back both directions and let the client-side app display both.

It also adds `Corsica` to allow CORS.