### PR TITLE
direction list now displays properly

### DIFF
--- a/lib/station/arrivals.ex
+++ b/lib/station/arrivals.ex
@@ -3,7 +3,7 @@ defmodule Commuter.Station.Arrivals do
   Handles functionality for arrivals data. This data has already been parsed from
   TFL-json to Train structs, and ends up being returned as an Arrivals struct.
   """
-  defstruct [inbound: [], outbound: []]
+  defstruct [inbound: %{trains: [], name: "Inbound"}, outbound: %{trains: [], name: "Outbound"}]
   alias Commuter.{Train}
   alias __MODULE__, as: Arrivals
 
@@ -11,26 +11,35 @@ defmodule Commuter.Station.Arrivals do
     %Arrivals{}
     |> put_into_direction_list(train_structs)
     |> sort_train_lists
+    |> add_direction_strings
   end
 
   defp put_into_direction_list(%Arrivals{} = arrivals, train_structs) do
     Enum.reduce(train_structs, arrivals, &(into_direction(&1,&2)))
   end
 
-  defp into_direction(%Train{direction: "inbound"} = train, %Arrivals{} = acc) do
-    %{acc | inbound: [train | acc.inbound]}
+  defp into_direction(%Train{direction: %{canonical: "inbound"}} = train, %Arrivals{} = acc) do
+    %{acc | inbound: add_to_train_list(acc.inbound, train)}
   end
 
-  defp into_direction(%Train{direction: "outbound"} = train, %Arrivals{} = acc) do
-    %{acc | outbound: [train | acc.outbound]}
+  defp into_direction(%Train{direction: %{canonical: "outbound"}} = train, %Arrivals{} = acc) do
+    %{acc | outbound: add_to_train_list(acc.outbound, train)}
   end
 
   defp into_direction(%Train{} = train, %Arrivals{} = acc), do: acc
 
-  defp sort_train_lists(%Arrivals{inbound: inb_list, outbound: outb_list} = struct) do
-    new_inb = sort_chronologically_with_interval(inb_list)
-    new_outb = sort_chronologically_with_interval(outb_list)
+  defp add_to_train_list(map, new_train) do
+    Map.update!(map, :trains, &([new_train | &1]) )
+  end
+
+  defp sort_train_lists(%Arrivals{inbound: inb_map, outbound: outb_map} = struct) do
+    new_inb = sort_train_list_chronologically(inb_map)
+    new_outb = sort_train_list_chronologically(outb_map)
     %{struct | inbound: new_inb, outbound: new_outb}
+  end
+
+  defp sort_train_list_chronologically(map) do
+    Map.update!(map, :trains, &(sort_chronologically_with_interval(&1)) )
   end
 
   defp sort_chronologically_with_interval(list) do
@@ -56,6 +65,28 @@ defmodule Commuter.Station.Arrivals do
   defp calculate_interval(%Train{time_to_station: time} = struct, {prev_time, list}) do
     interval = (time - prev_time)
     {time, [%{struct | interval: interval} | list]}
+  end
+
+  defp add_direction_strings(%Arrivals{inbound: inb, outbound: outb} = arrivals) do
+    new_inb = assign_name(inb)
+    new_outb = assign_name(outb)
+    %{arrivals | inbound: new_inb, outbound: new_outb}
+  end
+
+  defp assign_name(map) do
+    grab_first_train_direction(map.trains)
+    |> add_to_name(map)
+  end
+
+  defp grab_first_train_direction([]), do: :not_found
+  defp grab_first_train_direction(train_list) do
+    %Train{direction: %{name: direction_name}} = List.first(train_list)
+    direction_name
+  end
+
+  defp add_to_name(:not_found, map), do: map
+  defp add_to_name(direction_string, map) do
+    Map.put(map, :name, direction_string)
   end
 
 end

--- a/lib/tfl/station.ex
+++ b/lib/tfl/station.ex
@@ -33,7 +33,7 @@ defmodule Commuter.Tfl.Station do
   # Server callbacks
 
   def init(:ok) do
-    initial_state = create_station_list
+    initial_state = create_station_list()
     msg =
       "Initialised TFL Station list with #{inspect Enum.count(initial_state)} items"
     IO.puts msg

--- a/lib/train/train.ex
+++ b/lib/train/train.ex
@@ -1,8 +1,9 @@
 defmodule Commuter.Train do
-  @enforce_keys [:arrival_time, :location, :destination, :train_id, :direction]
+  @enforce_keys [:arrival_time, :location, :destination, :train_id]
 
   defstruct [ :arrival_time, :time_to_station, :location, :train_id, :interval,
-              :direction, destination: %{destination_name: nil, destination_id: nil}]
+              direction: %{canonical: nil, name: nil},
+              destination: %{destination_name: nil, destination_id: nil}]
 
   alias __MODULE__, as: Train
 
@@ -27,11 +28,25 @@ defmodule Commuter.Train do
         destination_id: map["destinationNaptanId"]
       },
       train_id: map["vehicleId"],
-      direction: map["direction"]
+      direction: %{
+        canonical: map["direction"],
+        name: directionName(map["platformName"])
+      }
     }
   end
+
   # Sometimes trains end up with no destination.
   defp tidy_name(nil), do: "Check front of train"
   defp tidy_name(string), do: String.replace(string, ~r/ Underground Station/, "")
+
+  defp directionName(string) do
+    # ~r/\w*bound\b/
+    # \w*bound\b
+    Regex.run(~r/\w*bound\b/, string)
+    |> getMatch(string)
+  end
+  
+  defp getMatch(nil, string), do: string
+  defp getMatch([match | _rest], string), do: match
 
 end

--- a/test/station/arrivals_test.exs
+++ b/test/station/arrivals_test.exs
@@ -15,30 +15,37 @@ defmodule Commuter.Station.ArrivalsTest do
 
   test "raw lists are just lists of train structs", %{trains: trains} do
     arr = Arrivals.build_arrivals(trains)
-    assert Enum.all?(arr.inbound, fn struct ->
+    assert Enum.all?(arr.inbound.trains, fn struct ->
       assert struct.__struct__ == Commuter.Train end)
-    assert Enum.all?(arr.outbound, fn struct ->
+    assert Enum.all?(arr.outbound.trains, fn struct ->
       assert struct.__struct__ == Commuter.Train end)
   end
 
   test "trains going in both directions are put in the right list", %{trains: trains} do
     arr = Arrivals.build_arrivals(trains)
-    Enum.each(arr.inbound, fn struct ->
-      assert struct.direction == "inbound" end)
-    Enum.each(arr.outbound, fn struct ->
-      assert struct.direction == "outbound" end)
+    refute Enum.count(arr.inbound.trains) == 0
+    refute Enum.count(arr.outbound.trains) == 0
+    Enum.all?(arr.inbound.trains, fn struct ->
+      assert struct.direction.canonical == "inbound" end)
+    Enum.all?(arr.outbound.trains, fn struct ->
+      assert struct.direction.canonical == "outbound" end)
   end
 
   test "trains are ordered chronologically by arrival time", %{trains: trains} do
-    list = Arrivals.build_arrivals(trains).outbound
+    list = Arrivals.build_arrivals(trains).outbound.trains
     arrival_times = Enum.map(list, fn map -> map.time_to_station end)
     sorted_arrival_times = Enum.sort(arrival_times)
     assert arrival_times == sorted_arrival_times
   end
 
   test "intervals are inserted correctly.", %{trains: trains} do
-    [one, two] = Arrivals.build_arrivals(trains).outbound |> Enum.take(2)
+    [one, two] = Arrivals.build_arrivals(trains).outbound.trains |> Enum.take(2)
     assert two.interval == (two.time_to_station - one.time_to_station)
+  end
+
+  test "both lists have proper *bound names", %{trains: trains} do
+    arr = Arrivals.build_arrivals(trains)
+    assert arr.inbound.name == "Northbound" || "Southbound"
   end
 
 end

--- a/test/train/train_test.exs
+++ b/test/train/train_test.exs
@@ -1,0 +1,17 @@
+defmodule Commuter.TrainTest do
+  use ExUnit.Case
+  alias Commuter.Train
+
+  setup do
+    response = Commuter.Tfl.Mock.line_arrivals(:test)
+    %{string: response}
+  end
+
+  test "only returns *bound as the direction", %{string: string} do
+    res = Train.create_train_structs(string)
+    Enum.all?(res, fn map ->
+      assert map.direction.name == "Northbound" || assert map.direction.name == "Southbound"
+    end)
+  end
+
+end


### PR DESCRIPTION
update the arrivals struct so that it now displays the direction name ("southbound" or "westbound", for instance) as well as a list of trains.