### PR TITLE
line supervisor now creates dispatcher and trains with registry

### DIFF
--- a/lib/choobio/lines/dispatcher.ex
+++ b/lib/choobio/lines/dispatcher.ex
@@ -5,17 +5,27 @@ defmodule Choobio.Line.Dispatcher do
   """
   use Supervisor
 
+  # Initialisation
+
   def start_link(line_id) do
     Supervisor.start_link(__MODULE__, [], name: __MODULE__)
   end
 
   def init(_) do
-    children = [
-      worker(Choobio.Train, [])
-    ]
+    children = [worker(Choobio.Train, [])]
     supervise(children, strategy: :simple_one_for_one)
   end
 
+  # Dispatching to trains
+
+  @doc """
+  Used to lookup a train process using its vehicle and line identifiers.
+
+  If the process already exists, returns `{:ok, ID}`.
+
+  If the process doesn't already exist, it creates it with the given `vehicle_id`
+  and will register it in the registry.
+  """
   def find_or_create_train({vehicle_id, line_id}) do
     if train_process_exists?({vehicle_id, line_id}) do
       {:ok, vehicle_id}
@@ -24,6 +34,10 @@ defmodule Choobio.Line.Dispatcher do
     end
   end
 
+  @doc """
+  Returns true if a train process already exists under supervision by this module,
+  false otherwise.
+  """
   def train_process_exists?({vehicle_id, line_id}) do
     registry = get_registry_name(line_id)
     case Registry.lookup(registry, vehicle_id) do
@@ -32,6 +46,12 @@ defmodule Choobio.Line.Dispatcher do
     end
   end
 
+  @doc """
+  Creates and Supervises a train process. See `Choobio.Train` for the details on
+  exactly what it is creating.
+
+  Will return error tuples if the process already exists, or any other reason.
+  """
   def create_train_process({vehicle_id, line_id}) do
     case Supervisor.start_child(__MODULE__, [{vehicle_id, line_id}]) do
       {:ok, pid} ->
@@ -43,11 +63,19 @@ defmodule Choobio.Line.Dispatcher do
     end
   end
 
+  # Helper Functions
+
+  @doc """
+  Counts number of train processes currently supervised.
+  """
   def train_process_count do
     Supervisor.which_children(__MODULE__) |> Enum.count
   end
 
-  def get_registry_name(line_id) do
+  @doc """
+  Shortcut to getting the registry name.
+  """
+  defp get_registry_name(line_id) do
     String.to_atom("#{line_id}_registry")
   end
 

--- a/lib/choobio/lines/dispatcher.ex
+++ b/lib/choobio/lines/dispatcher.ex
@@ -1,0 +1,54 @@
+defmodule Choobio.Line.Dispatcher do
+  @moduledoc """
+  Receives messages from TFL about trains and passes the data on to the relevant
+  train process, creating a new one if necessary.
+  """
+  use Supervisor
+
+  def start_link(line_id) do
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def init(_) do
+    children = [
+      worker(Choobio.Train, [])
+    ]
+    supervise(children, strategy: :simple_one_for_one)
+  end
+
+  def find_or_create_train({vehicle_id, line_id}) do
+    if train_process_exists?({vehicle_id, line_id}) do
+      {:ok, vehicle_id}
+    else
+      create_train_process({vehicle_id, line_id})
+    end
+  end
+
+  def train_process_exists?({vehicle_id, line_id}) do
+    registry = get_registry_name(line_id)
+    case Registry.lookup(registry, vehicle_id) do
+      [] -> false
+      _ -> true
+    end
+  end
+
+  def create_train_process({vehicle_id, line_id}) do
+    case Supervisor.start_child(__MODULE__, [{vehicle_id, line_id}]) do
+      {:ok, pid} ->
+        {:ok, vehicle_id}
+      {:error, {:already_started, _pid}} ->
+        {:error, :process_already_exists}
+      other ->
+        {:error, other}
+    end
+  end
+
+  def train_process_count do
+    Supervisor.which_children(__MODULE__) |> Enum.count
+  end
+
+  def get_registry_name(line_id) do
+    String.to_atom("#{line_id}_registry")
+  end
+
+end

--- a/lib/choobio/lines/monitor.ex
+++ b/lib/choobio/lines/monitor.ex
@@ -11,7 +11,7 @@ defmodule Choobio.Line.Monitor do
 	end
 
 	def get_new_data_from_tfl(id) do
-		get_trains
+		get_trains()
 		|> find_train(id)
 	end
 

--- a/lib/choobio/lines/supervisor.ex
+++ b/lib/choobio/lines/supervisor.ex
@@ -1,0 +1,24 @@
+defmodule Choobio.Line.Supervisor do
+  @moduledoc """
+  Supervises the creation of processes associated with a Tube Line.
+  Starts the following processes:
+
+  - A `Dispatcher` to receive messages from TFL, create train processes and update
+  them with that data.
+  - A `Registry` to hold information about the train processes.
+  """
+  use Supervisor
+  alias Choobio.Line.Dispatcher
+
+  def start_link(line_id) do
+    registry_name = String.to_atom("#{line_id}_registry")
+    children = [
+      supervisor(Registry, [:unique, registry_name]),
+      supervisor(Dispatcher, [line_id])
+    ]
+
+    opts = [strategy: :one_for_one, name: LineSupervisor]
+    Supervisor.start_link(children, opts)
+  end
+
+end

--- a/lib/choobio/lines/supervisor.ex
+++ b/lib/choobio/lines/supervisor.ex
@@ -10,6 +10,9 @@ defmodule Choobio.Line.Supervisor do
   use Supervisor
   alias Choobio.Line.Dispatcher
 
+  @doc """
+  Starts the supervision tree outlined in the module docs.
+  """
   def start_link(line_id) do
     registry_name = String.to_atom("#{line_id}_registry")
     children = [

--- a/lib/choobio/train/train.ex
+++ b/lib/choobio/train/train.ex
@@ -1,27 +1,39 @@
 defmodule Choobio.Train do
+  @moduledoc """
+  When started under a supervision tree, like `Choobio.Line.Supervisor`, this module
+  creates a genserver representing one train on the network.
+
+  The functionality here is all around holding state about where the train is, and
+  how long it has had its doors open for throughout its journey.
+
+  When the process is started, it can send and receive messages to receive
+  data from TFL via a `Dispatcher`.
+  """
   use GenServer
   alias __MODULE__, as: Train
   alias Choobio.Tfl
 
+  # Initialisation
+
+  @doc """
+  Starts a train process and registers its name in the registry relating to `line_id`.
+
+  A train that receives `{"001", "northern"}` will be registered in `:northern_registry`
+  under the key "001".
+  """
 	def start_link({vehicle_id, line_id}) do
 		init_args = {vehicle_id}
 		{:ok, _} = GenServer.start_link(__MODULE__, init_args, name: via_tuple({vehicle_id, line_id}))
 	end
 
-  def via_tuple({vehicle_id, line_id}) do
-    registry = get_registry_name(line_id)
-    {:via, Registry, {registry, vehicle_id}}
-  end
+  # Public API
 
-	def init({vehicle_id}) do
-		state = %{id: vehicle_id, location: "init", next_station: "init"}
-		{:ok, state}
-	end
+  @doc """
+  Returns the process ID of a train process, or nil if it doesn't exist in this
+  registry.
 
-  defp get_registry_name(line_id) do
-    String.to_atom("#{line_id}_registry")
-  end
-
+  The registry is specific to the line, based on `line_id` given to this function.
+  """
   def whereis({vehicle_id, line_id}) do
     registry = get_registry_name(line_id)
     case Registry.lookup(registry, vehicle_id) do
@@ -30,24 +42,41 @@ defmodule Choobio.Train do
     end
   end
 
+  @doc """
+  Returns the current location of the train
+  """
 	def get_location({vehicle_id, line_id}) do
 		GenServer.call(via_tuple({vehicle_id, line_id}), :get_location)
 	end
 
+  @doc """
+  Updates the process state with the new location data, which has presumably
+  arrived via `Dispatcher` from TFL.
+  """
 	def update({vehicle_id, line_id}, new_data) do
 		GenServer.cast(via_tuple({vehicle_id, line_id}), {:update_location, new_data})
 	end
 
+  # Genserver
+
+  @doc """
+  See `&get_location/1` for details
+  """
 	def handle_call(:get_location, _from, state) do
 		{:reply, state, state}
 	end
 
+  @doc """
+  See `&update/2` for details
+  """
 	def handle_cast({:update_location, new_data}, state) do
 		new_state = update_location(new_data, state)
 		now = DateTime.utc_now()
 		IO.puts "\n#{now.hour}:#{now.minute}:#{now.second} :: #{inspect new_state}\n"
 		{:noreply, new_state}
 	end
+
+  # Private functions
 
 	defp update_location(new_data, old_location) do
 		new_loc = Map.get(new_data, :location)
@@ -56,5 +85,27 @@ defmodule Choobio.Train do
 		|> Map.put(:next_station, new_stat)
 		|> Map.put(:location, new_loc)
 	end
+
+  @doc """
+  Used to register the process name under its vehicle ID in the registry.
+
+  See `&start_link/1` for more details.
+  """
+  def via_tuple({vehicle_id, line_id}) do
+    registry = get_registry_name(line_id)
+    {:via, Registry, {registry, vehicle_id}}
+  end
+
+  @doc """
+  Initialises the process with a basic location map.
+  """
+  def init({vehicle_id}) do
+    state = %{id: vehicle_id, location: "init", next_station: "init"}
+    {:ok, state}
+  end
+
+  defp get_registry_name(line_id) do
+    String.to_atom("#{line_id}_registry")
+  end
 
 end


### PR DESCRIPTION
Implements a `LineSupervisor` which, when started, supervises:

- A `LineDispatcher` that dynamically starts `Train` processes using data (eventually) drawn from TFL.
- A unique Registry module that holds info about these Train processes.

Right now, you can't start more than one LineSupervisor. For that, we'll need something like a `NetworkSupervisor` which is responsible for starting a `LineSupervisor` for every single line. There's a decent map in one of the issues.